### PR TITLE
Add functionality to also search on content

### DIFF
--- a/app/src/main/java/com/digiventure/ventnote/feature/notes/NotesPage.kt
+++ b/app/src/main/java/com/digiventure/ventnote/feature/notes/NotesPage.kt
@@ -72,7 +72,7 @@ fun NotesPage(
     val snackBarHostState = remember { SnackbarHostState() }
     val filteredNotes = remember(noteListState.value, viewModel.searchedTitleText.value) {
         noteListState.value?.getOrNull()?.filter { note ->
-            note.title.contains(viewModel.searchedTitleText.value, true)
+            note.title.contains(viewModel.searchedTitleText.value, true) || note.content.contains(viewModel.searchedTitleText.value, true)
         } ?: listOf()
     }
     val loadingDialog = remember { mutableStateOf(false) }


### PR DESCRIPTION
**Background**
Currently we can only search based on note title

**Changes**
Enable to also search on note content alongside title

Notes:
If this idea is valuable and approved, perhaps we need to also rename the placeholder and corresponding attribute name from `searchedTitleText` to something like `searchKeywordText`