### PR TITLE
Merge adaptive screen into 1.4.0

### DIFF
--- a/app/src/androidTest/java/com/digiventure/ventnote/NoteCreationFeature.kt
+++ b/app/src/androidTest/java/com/digiventure/ventnote/NoteCreationFeature.kt
@@ -91,19 +91,39 @@ class NoteCreationFeature : BaseAcceptanceTest() {
     }
 
     /**
-     * Verifies that a validation dialog is shown when trying to save with an empty title.
+     * Verifies that saving with an empty title adds the note successfully.
      */
     @Test
-    fun saveFlow_validation_emptyTitle_showsRequiredDialog() {
-        // Leave title empty, add body
-        composeTestRule.onNodeWithTag(TestTags.BODY_TEXT_FIELD).performTextInput("Some content")
+    fun saveFlow_withEmptyTitle_successfullyAddsNote() {
+        val body = "New Note Body Content"
+
+        composeTestRule.onNodeWithTag(TestTags.BODY_TEXT_FIELD).performTextInput(body)
         
-        composeTestRule.onNodeWithTag(TestTags.SAVE_ICON_BUTTON).performClick()
+        // Ensure no validation dialog is present
+        composeTestRule.onNodeWithTag(TestTags.CONFIRMATION_DIALOG).assertDoesNotExist()
+        
+        composeTestRule.onNodeWithTag(TestTags.SAVE_ICON_BUTTON).performTouchInput { click() }
         composeTestRule.waitForIdle()
 
-        // Validation dialog should appear
-        composeTestRule.onNodeWithTag(TestTags.CONFIRMATION_DIALOG).assertIsDisplayed()
-        composeTestRule.onNodeWithTag(TestTags.CONFIRM_BUTTON).performClick()
+        // Should navigate back to list
+        composeTestRule.waitUntil(15000) {
+            try {
+                composeTestRule.onNodeWithTag(TestTags.NOTES_PAGE).assertIsDisplayed()
+                true
+            } catch (e: Throwable) {
+                false
+            }
+        }
+        
+        composeTestRule.waitUntil(10000) {
+            try {
+                // Should display Untitled fallback
+                composeTestRule.onNodeWithText("Untitled").assertIsDisplayed()
+                true
+            } catch (e: Throwable) {
+                false
+            }
+        }
     }
 
     /**

--- a/app/src/androidTest/java/com/digiventure/ventnote/NoteDetailFeature.kt
+++ b/app/src/androidTest/java/com/digiventure/ventnote/NoteDetailFeature.kt
@@ -134,22 +134,27 @@ class NoteDetailFeature : BaseAcceptanceTest() {
     }
 
     /**
-     * Verifies that a validation dialog is shown when trying to save an empty title.
+     * Verifies that updating a note with an empty title succeeds.
      */
     @Test
-    fun saveFlow_validation_emptyTitle_showsRequiredDialog() {
+    fun saveFlow_withEmptyTitle_successfullyUpdatesNote() {
         composeTestRule.onNodeWithTag(TestTags.EDIT_ICON_BUTTON).performClick()
         composeTestRule.waitForIdle()
 
         // Clear title
         composeTestRule.onNodeWithTag(TestTags.TITLE_TEXT_FIELD).performTextReplacement("")
         
+        // Ensure no validation dialog is present
+        composeTestRule.onNodeWithTag(TestTags.CONFIRMATION_DIALOG).assertDoesNotExist()
+        
         composeTestRule.onNodeWithTag(TestTags.SAVE_ICON_BUTTON).performClick()
         composeTestRule.waitForIdle()
 
-        // Validation dialog should appear
-        composeTestRule.onNodeWithTag(TestTags.CONFIRMATION_DIALOG).assertIsDisplayed()
-        composeTestRule.onNodeWithTag(TestTags.CONFIRM_BUTTON).performClick() // Dismiss it
+        // Should return to view mode (Edit button reappears)
+        composeTestRule.onNodeWithTag(TestTags.EDIT_ICON_BUTTON).assertIsDisplayed()
+        
+        // In NoteDetailPage, the title field displays the empty text if it is empty, but we might just verify it's empty
+        composeTestRule.onNodeWithTag(TestTags.TITLE_TEXT_FIELD).assertTextContains("")
     }
 
     /**

--- a/app/src/main/java/com/digiventure/ventnote/commons/richtext/RichTextEditor.kt
+++ b/app/src/main/java/com/digiventure/ventnote/commons/richtext/RichTextEditor.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -86,33 +87,55 @@ fun RichTextEditor(
                 )
             }
 
-            BasicTextField(
-                value = richTextState.textFieldValue,
-                onValueChange = { newValue ->
-                    if (!readOnly) {
-                        richTextState.onTextFieldValueChange(newValue)
-                    }
-                },
-                readOnly = readOnly,
-                textStyle = MaterialTheme.typography.titleMedium.copy(
-                    color = MaterialTheme.colorScheme.onSurface
-                ),
-                cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .fillMaxHeight()
-                    .onFocusChanged { focusState ->
-                        onFocusChanged?.invoke(focusState.isFocused)
-                    }
-                    .semantics {
-                        if (testTagText.isNotEmpty()) {
-                            testTag = testTagText
+            if (readOnly) {
+                SelectionContainer {
+                    Text(
+                        text = richTextState.textFieldValue.annotatedString,
+                        style = MaterialTheme.typography.titleMedium.copy(
+                            color = MaterialTheme.colorScheme.onSurface
+                        ),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .fillMaxHeight()
+                            .semantics {
+                                if (testTagText.isNotEmpty()) {
+                                    testTag = testTagText
+                                }
+                                if (contentDescriptionText.isNotEmpty()) {
+                                    contentDescription = contentDescriptionText
+                                }
+                            }
+                    )
+                }
+            } else {
+                BasicTextField(
+                    value = richTextState.textFieldValue,
+                    onValueChange = { newValue ->
+                        if (!readOnly) {
+                            richTextState.onTextFieldValueChange(newValue)
                         }
-                        if (contentDescriptionText.isNotEmpty()) {
-                            contentDescription = contentDescriptionText
+                    },
+                    readOnly = readOnly,
+                    textStyle = MaterialTheme.typography.titleMedium.copy(
+                        color = MaterialTheme.colorScheme.onSurface
+                    ),
+                    cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .fillMaxHeight()
+                        .onFocusChanged { focusState ->
+                            onFocusChanged?.invoke(focusState.isFocused)
                         }
-                    }
-            )
+                        .semantics {
+                            if (testTagText.isNotEmpty()) {
+                                testTag = testTagText
+                            }
+                            if (contentDescriptionText.isNotEmpty()) {
+                                contentDescription = contentDescriptionText
+                            }
+                        }
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/digiventure/ventnote/feature/note_creation/NoteCreationPage.kt
+++ b/app/src/main/java/com/digiventure/ventnote/feature/note_creation/NoteCreationPage.kt
@@ -5,8 +5,11 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -110,7 +113,7 @@ fun NoteCreationPage(
         val titlePlain = viewModel.titleRichTextState.toPlainText()
         val bodyPlain = viewModel.richTextState.toPlainText()
 
-        if (titlePlain.isEmpty() || bodyPlain.isEmpty()) {
+        if (bodyPlain.isEmpty()) {
             requiredDialogState.value = true
         } else {
             scope.launch {
@@ -161,17 +164,24 @@ fun NoteCreationPage(
             )
         },
         content = { contentPadding ->
+            androidx.compose.foundation.layout.Box(
+                modifier = Modifier
+                    .padding(contentPadding)
+                    .fillMaxSize(),
+                contentAlignment = androidx.compose.ui.Alignment.TopCenter
+            ) {
             // Better scrolling performance with LazyColumn
             LazyColumn(
                 modifier = Modifier
-                    .padding(contentPadding)
                     .clickable(
                         indication = null,
                         interactionSource = remember { MutableInteractionSource() }
                     ) {
                         focusManager.clearFocus()
                     }
-                    .fillMaxSize(),
+                    .fillMaxHeight()
+                    .widthIn(max = 800.dp)
+                    .fillMaxWidth(),
                 contentPadding = PaddingValues(
                     horizontal = 16.dp,
                     vertical = 8.dp
@@ -257,6 +267,7 @@ fun NoteCreationPage(
                     )
                 }
             }
+            }
         },
         bottomBar = {
             EnhancedBottomAppBar(
@@ -271,16 +282,10 @@ fun NoteCreationPage(
     )
 
     // Optimized missing field calculation
-    val emptyTitleText = stringResource(R.string.empty_note_title_placeholder)
     val emptyNoteText = stringResource(R.string.empty_note_placeholder)
-    val titlePlainText = viewModel.titleRichTextState.toPlainText()
     val noteBodyText = viewModel.richTextState.toPlainText()
-    val missingFieldName = remember(titlePlainText, noteBodyText) {
-        when {
-            titlePlainText.isEmpty() -> emptyTitleText
-            noteBodyText.isEmpty() -> emptyNoteText
-            else -> EMPTY_STRING
-        }
+    val missingFieldName = remember(noteBodyText) {
+        if (noteBodyText.isEmpty()) emptyNoteText else EMPTY_STRING
     }
 
     if (requiredDialogState.value) {

--- a/app/src/main/java/com/digiventure/ventnote/feature/note_detail/NoteDetailPage.kt
+++ b/app/src/main/java/com/digiventure/ventnote/feature/note_detail/NoteDetailPage.kt
@@ -7,7 +7,9 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -181,7 +183,7 @@ fun NoteDetailPage(
             val titlePlain = viewModel.titleRichTextState.toPlainText()
             val bodyPlain = viewModel.richTextState.toPlainText()
 
-            if (titlePlain.isEmpty() || bodyPlain.isEmpty()) {
+            if (bodyPlain.isEmpty()) {
                 requiredDialogState.value = true
             } else {
                 data?.let { noteData ->
@@ -258,10 +260,17 @@ fun NoteDetailPage(
         },
         snackbarHost = { SnackbarHost(snackBarHostState) },
         content = { contentPadding ->
+            androidx.compose.foundation.layout.Box(
+                modifier = Modifier
+                    .padding(contentPadding)
+                    .fillMaxSize(),
+                contentAlignment = androidx.compose.ui.Alignment.TopCenter
+            ) {
             LazyColumn(
                 modifier = Modifier
-                    .fillMaxSize()
-                    .padding(contentPadding)
+                    .fillMaxHeight()
+                    .widthIn(max = 800.dp)
+                    .fillMaxWidth()
                     .padding(horizontal = 16.dp)
                     .clickable(
                         indication = null,
@@ -364,6 +373,7 @@ fun NoteDetailPage(
                     )
                 }
             }
+            }
         },
         bottomBar = {
             EnhancedBottomAppBar(
@@ -385,20 +395,13 @@ fun NoteDetailPage(
     )
 
     // Dialogs
-    val titlePlaceholderText = stringResource(R.string.title_textField_input)
     val notePlaceholderText = stringResource(R.string.body_textField_input)
 
-    val titlePlainText = viewModel.titleRichTextState.toPlainText()
     val noteBodyText = viewModel.richTextState.toPlainText()
     val missingFieldName = remember(
-        titlePlainText,
         noteBodyText
     ) {
-        when {
-            titlePlainText.isEmpty() -> titlePlaceholderText
-            noteBodyText.isEmpty() -> notePlaceholderText
-            else -> EMPTY_STRING
-        }
+        if (noteBodyText.isEmpty()) notePlaceholderText else EMPTY_STRING
     }
 
     if (requiredDialogState.value) {

--- a/app/src/main/java/com/digiventure/ventnote/feature/notes/NotesPage.kt
+++ b/app/src/main/java/com/digiventure/ventnote/feature/notes/NotesPage.kt
@@ -304,7 +304,7 @@ fun NotesPage(
                 when (viewModel.noteViewMode.value) {
                     Constants.VIEW_MODE_STAGGERED -> {
                         LazyVerticalStaggeredGrid(
-                            columns = StaggeredGridCells.Fixed(2),
+                            columns = StaggeredGridCells.Adaptive(minSize = 160.dp),
                             modifier = listModifier,
                             verticalItemSpacing = 16.dp,
                             horizontalArrangement = Arrangement.spacedBy(16.dp),

--- a/app/src/main/java/com/digiventure/ventnote/feature/notes/components/item/NoteItem.kt
+++ b/app/src/main/java/com/digiventure/ventnote/feature/notes/components/item/NoteItem.kt
@@ -133,8 +133,9 @@ fun NotesItem(
                             .semantics { }) {
                     }
                 }
+                val titleText = if (data.title.isEmpty()) androidx.compose.ui.res.stringResource(com.digiventure.ventnote.R.string.untitled) else data.title
                 Text(
-                    text = MarkdownParser.parseToAnnotatedString(data.title),
+                    text = MarkdownParser.parseToAnnotatedString(titleText),
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     style = MaterialTheme.typography.titleMedium.copy(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,8 +2,8 @@
     <string name="app_name">VentNote</string>
 
     <string name="fab">fab</string>
-
     <string name="title">VentNote</string>
+    <string name="untitled">Untitled</string>
 
     <!--  Top Appbar Components  -->
     <string name="close_nav_icon">close nav icon</string>


### PR DESCRIPTION
## Overview
This PR introduces **Adaptive Layout Enhancements** and makes note titles **optional**. The UI has been optimized to better support wide screens, tablets, and foldable devices, while improving the general user experience and flexibility when creating and viewing notes.

## Changes
* **Optional Note Titles:** Users can now create and save notes without needing to provide a title. The validation checks have been updated to only prompt if the note body itself is empty.
* **UI Fallbacks & Polish:** Added a seamless fallback for empty titles. Notes without a title will display "Untitled" in the list view to ensure the cards remain visually consistent and easy to tap. 
* **Selectable View-Mode Text:** Enhanced the Note Detail page by wrapping the content in a `SelectionContainer`, allowing users to naturally highlight and copy text while viewing a note without having to enter edit mode first.
* **Adaptive Grid Layout:** Upgraded the main notes list staggered grid to use an adaptive column count rather than a fixed 2-column layout. It now dynamically scales the number of columns based on the screen's width.
* **Wide Screen Constraints:** Added a maximum width constraint (`800.dp`) to the note creation and note detail pages. This centers the content and prevents text fields from stretching uncomfortably wide on ultra-wide displays.
* **Automated Testing:** Updated the Espresso UI tests to verify the new optional title logic and ensure the creation/editing flows succeed correctly without a title.

## Tech Stack / Version Info
* **Branch:** `adaptive-screen-1.4.0`
* **Target Version:** 1.4.0
